### PR TITLE
feat: UX improvements — clean outputs, new domain tools, safe DNS update

### DIFF
--- a/dist/client.js
+++ b/dist/client.js
@@ -86,9 +86,17 @@ export class NamecheapClient {
             const first = errorList[0];
             const code = String(first?.['@_Number'] ?? 'UNKNOWN');
             let message = String(first?.['#text'] ?? 'Unknown error');
-            if (code === '1011102' || code === '1011150') {
-                message += ' — ensure NAMECHEAP_CLIENT_IP is set to your whitelisted public IP address';
-            }
+            const ERROR_HINTS = {
+                '1011102': ' — ensure NAMECHEAP_CLIENT_IP is whitelisted at ap.www.namecheap.com/settings/tools/apiaccess/',
+                '1011150': ' — ensure NAMECHEAP_CLIENT_IP is whitelisted at ap.www.namecheap.com/settings/tools/apiaccess/',
+                '2016166': ' — domain not found in your account',
+                '2019166': ' — domain is locked; use set_registrar_lock to unlock before this operation',
+                '3031510': ' — insufficient account balance',
+                '2030280': ' — invalid nameserver format',
+            };
+            const hint = ERROR_HINTS[code];
+            if (hint)
+                message += hint;
             throw new NamecheapApiError(message, code, command);
         }
         return apiResponse.CommandResponse;

--- a/dist/tools/account.js
+++ b/dist/tools/account.js
@@ -7,7 +7,16 @@ export function registerAccountTools(server, getClient) {
     }, async () => {
         try {
             const result = await requireClient(getClient).execute('namecheap.users.getBalances', {});
-            return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+            const r = result?.['UserGetBalancesResult'] ?? {};
+            const clean = {
+                currency: r['@_Currency'] ?? '',
+                availableBalance: parseFloat(r['@_AvailableBalance'] ?? '0'),
+                accountBalance: parseFloat(r['@_AccountBalance'] ?? '0'),
+                earnedAmount: parseFloat(r['@_EarnedAmount'] ?? '0'),
+                withdrawableAmount: parseFloat(r['@_WithdrawableAmount'] ?? '0'),
+                fundsRequiredForAutoRenew: parseFloat(r['@_FundsRequiredForAutoRenew'] ?? '0'),
+            };
+            return { content: [{ type: 'text', text: JSON.stringify(clean, null, 2) }] };
         }
         catch (err) {
             return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };

--- a/dist/tools/dns.js
+++ b/dist/tools/dns.js
@@ -1,5 +1,30 @@
 import { z } from 'zod';
 import { requireClient } from '../config.js';
+const RECORD_TYPES = ['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'URL', 'URL301', 'FRAME'];
+function parseHosts(result) {
+    const r = result?.['DomainDNSGetHostsResult'];
+    const raw = r?.['Host'];
+    return Array.isArray(raw) ? raw : raw ? [raw] : [];
+}
+function cleanHosts(result) {
+    const r = result?.['DomainDNSGetHostsResult'];
+    const raw = r?.['Host'];
+    const list = Array.isArray(raw) ? raw : raw ? [raw] : [];
+    return {
+        domain: r?.['@_Domain'] ?? '',
+        usingNamecheapDns: r?.['@_IsUsingOurDNS'] === 'true',
+        emailType: r?.['@_EmailType'] ?? '',
+        hosts: list.map(h => ({
+            id: h['@_HostId'],
+            name: h['@_Name'],
+            type: h['@_Type'],
+            address: h['@_Address'],
+            ttl: parseInt(h['@_TTL'] ?? '1800', 10),
+            mxPref: parseInt(h['@_MXPref'] ?? '0', 10),
+            active: h['@_IsActive'] === 'true',
+        })),
+    };
+}
 export function registerDnsTools(server, getClient) {
     server.registerTool('get_dns_hosts', {
         description: 'Get all DNS host records for a domain (A, AAAA, CNAME, MX, TXT, NS, etc.).',
@@ -9,7 +34,7 @@ export function registerDnsTools(server, getClient) {
             const client = requireClient(getClient);
             const { sld, tld } = client.splitDomain(domainName);
             const result = await client.execute('namecheap.domains.dns.getHosts', { SLD: sld, TLD: tld });
-            return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+            return { content: [{ type: 'text', text: JSON.stringify(cleanHosts(result), null, 2) }] };
         }
         catch (err) {
             return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
@@ -21,8 +46,7 @@ export function registerDnsTools(server, getClient) {
             domainName: z.string().describe('The domain name, e.g. "example.com"'),
             hosts: z.array(z.object({
                 hostName: z.string().describe('Host/subdomain name. Use "@" for root, "*" for wildcard.'),
-                recordType: z.enum(['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'URL', 'URL301', 'FRAME'])
-                    .describe('DNS record type'),
+                recordType: z.enum(RECORD_TYPES).describe('DNS record type'),
                 address: z.string().describe('Record value (IP address, hostname, or URL)'),
                 mxPref: z.number().int().min(0).max(65535).optional().describe('MX priority (required for MX records, 0–65535)'),
                 ttl: z.number().int().optional().describe('TTL in seconds (default: 1800)'),
@@ -35,6 +59,86 @@ export function registerDnsTools(server, getClient) {
             const hostParams = client.flattenHostRecords(hosts);
             const result = await client.execute('namecheap.domains.dns.setHosts', { SLD: sld, TLD: tld, ...hostParams }, 'POST');
             return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+        }
+        catch (err) {
+            return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+        }
+    });
+    server.registerTool('update_dns_record', {
+        description: 'Safely adds, updates, or removes a single DNS record without affecting other records. ' +
+            'Performs an internal read-modify-write — no need to call get_dns_hosts first. ' +
+            'For upsert: finds a matching record by hostName + recordType (MX records also match on address) and replaces it, or appends if not found. ' +
+            'For delete: removes the matching record.',
+        inputSchema: {
+            domainName: z.string().describe('The domain name, e.g. "example.com"'),
+            operation: z.enum(['upsert', 'delete']).describe('"upsert" to add or update a record, "delete" to remove it'),
+            record: z.object({
+                hostName: z.string().describe('Host/subdomain name. Use "@" for root, "*" for wildcard.'),
+                recordType: z.enum(RECORD_TYPES).describe('DNS record type'),
+                address: z.string().optional().describe('Record value (required for upsert)'),
+                mxPref: z.number().int().min(0).max(65535).optional().describe('MX priority (required for MX upsert)'),
+                ttl: z.number().int().optional().describe('TTL in seconds (default: 1800)'),
+            }).describe('The record to add, update, or delete'),
+        },
+    }, async ({ domainName, operation, record }) => {
+        try {
+            const client = requireClient(getClient);
+            const { sld, tld } = client.splitDomain(domainName);
+            if (operation === 'upsert' && !record.address) {
+                return { content: [{ type: 'text', text: 'Error: address is required for upsert' }], isError: true };
+            }
+            if (operation === 'upsert' && record.recordType === 'MX' && record.mxPref === undefined) {
+                return { content: [{ type: 'text', text: 'Error: mxPref is required for MX upsert' }], isError: true };
+            }
+            // Read current records
+            const existing = await client.execute('namecheap.domains.dns.getHosts', { SLD: sld, TLD: tld });
+            const rawHosts = parseHosts(existing);
+            // Convert raw hosts to HostRecord format
+            const currentRecords = rawHosts.map(h => ({
+                hostName: h['@_Name'] ?? '',
+                recordType: h['@_Type'],
+                address: h['@_Address'] ?? '',
+                mxPref: h['@_MXPref'] ? parseInt(h['@_MXPref'], 10) : undefined,
+                ttl: h['@_TTL'] ? parseInt(h['@_TTL'], 10) : 1800,
+            }));
+            const isMx = record.recordType === 'MX';
+            const matches = (h) => h.hostName === record.hostName &&
+                h.recordType === record.recordType &&
+                (!isMx || h.address === record.address);
+            let updatedRecords;
+            if (operation === 'delete') {
+                updatedRecords = currentRecords.filter(h => !matches(h));
+            }
+            else {
+                const newRecord = {
+                    hostName: record.hostName,
+                    recordType: record.recordType,
+                    address: record.address,
+                    mxPref: record.mxPref,
+                    ttl: record.ttl ?? 1800,
+                };
+                const idx = currentRecords.findIndex(h => matches(h));
+                if (idx >= 0) {
+                    updatedRecords = [...currentRecords];
+                    updatedRecords[idx] = newRecord;
+                }
+                else {
+                    updatedRecords = [...currentRecords, newRecord];
+                }
+            }
+            const hostParams = client.flattenHostRecords(updatedRecords);
+            await client.execute('namecheap.domains.dns.setHosts', { SLD: sld, TLD: tld, ...hostParams }, 'POST');
+            return {
+                content: [{
+                        type: 'text',
+                        text: JSON.stringify({
+                            operation,
+                            domain: domainName,
+                            record: { hostName: record.hostName, type: record.recordType },
+                            totalRecords: updatedRecords.length,
+                        }, null, 2),
+                    }],
+            };
         }
         catch (err) {
             return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };

--- a/dist/tools/dns.js
+++ b/dist/tools/dns.js
@@ -101,10 +101,12 @@ export function registerDnsTools(server, getClient) {
                 mxPref: h['@_MXPref'] ? parseInt(h['@_MXPref'], 10) : undefined,
                 ttl: h['@_TTL'] ? parseInt(h['@_TTL'], 10) : 1800,
             }));
-            const isMx = record.recordType === 'MX';
+            // For MX records, also match on address when provided (multiple MX records
+            // with different addresses can share the same hostName + recordType).
+            // When address is omitted on a delete, match all MX records at that hostName.
             const matches = (h) => h.hostName === record.hostName &&
                 h.recordType === record.recordType &&
-                (!isMx || h.address === record.address);
+                (record.recordType !== 'MX' || !record.address || h.address === record.address);
             let updatedRecords;
             if (operation === 'delete') {
                 updatedRecords = currentRecords.filter(h => !matches(h));

--- a/dist/tools/domains.js
+++ b/dist/tools/domains.js
@@ -106,7 +106,7 @@ export function registerDomainTools(server, getClient) {
                 locked: r['@_IsLocked'] === 'true',
                 autoRenew: r['@_AutoRenew'] === 'true',
                 whoisGuard: wg ? {
-                    enabled: wg['@_Enabled'] === 'true',
+                    enabled: wg['@_Enabled'] === 'ENABLED',
                     id: wg['@_ID'],
                     expires: wg['@_ExpiredDate'],
                 } : null,
@@ -184,7 +184,7 @@ export function registerDomainTools(server, getClient) {
         try {
             await requireClient(getClient).execute('namecheap.domains.autoRenew', {
                 DomainName: domainName,
-                flag: autoRenew ? 'true' : 'false',
+                Flag: autoRenew ? 'true' : 'false',
             });
             return { content: [{ type: 'text', text: JSON.stringify({ domain: domainName, autoRenew }, null, 2) }] };
         }
@@ -210,6 +210,12 @@ export function registerDomainTools(server, getClient) {
                 };
             }
             const whoisguardId = wg['@_ID'];
+            if (!whoisguardId) {
+                return {
+                    content: [{ type: 'text', text: `WHOIS guard ID missing for ${domainName} — cannot enable/disable.` }],
+                    isError: true,
+                };
+            }
             const command = enable ? 'namecheap.whoisguard.enable' : 'namecheap.whoisguard.disable';
             await client.execute(command, { WhoisguardId: whoisguardId });
             return { content: [{ type: 'text', text: JSON.stringify({ domain: domainName, whoisGuard: enable ? 'ENABLED' : 'DISABLED' }, null, 2) }] };

--- a/dist/tools/domains.js
+++ b/dist/tools/domains.js
@@ -7,14 +7,27 @@ export function registerDomainTools(server, getClient) {
     }, async ({ domains }) => {
         try {
             const result = await requireClient(getClient).execute('namecheap.domains.check', { DomainList: domains });
-            return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+            const raw = result?.['DomainCheckResult'];
+            const list = Array.isArray(raw) ? raw : raw ? [raw] : [];
+            const clean = list.map(d => {
+                const isPremium = d['@_IsPremiumName'] === 'true';
+                const entry = {
+                    domain: d['@_Domain'],
+                    available: d['@_Available'] === 'true',
+                    isPremium,
+                };
+                if (isPremium)
+                    entry['premiumPrice'] = parseFloat(d['@_PremiumRegistrationPrice'] ?? '0');
+                return entry;
+            });
+            return { content: [{ type: 'text', text: JSON.stringify(clean, null, 2) }] };
         }
         catch (err) {
             return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
         }
     });
     server.registerTool('list_domains', {
-        description: 'List all domains in your Namecheap account. Supports pagination and search filtering.',
+        description: 'List all domains in your Namecheap account. Supports pagination and search filtering. Call with increasing page values until hasNextPage is false to retrieve all domains.',
         inputSchema: {
             page: z.number().int().min(1).optional().describe('Page number (default: 1)'),
             pageSize: z.number().int().min(1).max(100).optional().describe('Results per page, max 100 (default: 20)'),
@@ -24,16 +37,46 @@ export function registerDomainTools(server, getClient) {
     }, async ({ page, pageSize, searchTerm, listType }) => {
         try {
             const client = requireClient(getClient);
+            const currentPage = page ?? 1;
+            const currentPageSize = pageSize ?? 20;
             const params = {
-                Page: page ?? 1,
-                PageSize: pageSize ?? 20,
+                Page: currentPage,
+                PageSize: currentPageSize,
             };
             if (searchTerm)
                 params['SearchTerm'] = searchTerm;
             if (listType)
                 params['ListType'] = listType;
             const result = await client.execute('namecheap.domains.getList', params);
-            return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+            const r = result;
+            const raw = r?.['DomainGetListResult'];
+            const paging = r?.['Paging'];
+            const domainList = raw?.['Domain'];
+            const list = Array.isArray(domainList) ? domainList : domainList ? [domainList] : [];
+            const domainsMapped = list.map(d => ({
+                id: d['@_ID'],
+                name: d['@_Name'],
+                created: d['@_Created'],
+                expires: d['@_Expires'],
+                expired: d['@_IsExpired'] === 'true',
+                locked: d['@_IsLocked'] === 'true',
+                autoRenew: d['@_AutoRenew'] === 'true',
+                whoisGuard: d['@_WhoisGuard'],
+                usingNamecheapDns: d['@_IsOurDNS'] === 'true',
+            }));
+            const totalItems = parseInt(paging?.['TotalItems'] ?? '0', 10);
+            const totalPages = Math.ceil(totalItems / currentPageSize);
+            const clean = {
+                domains: domainsMapped,
+                pagination: {
+                    page: currentPage,
+                    pageSize: currentPageSize,
+                    totalItems,
+                    totalPages,
+                    hasNextPage: currentPage < totalPages,
+                },
+            };
+            return { content: [{ type: 'text', text: JSON.stringify(clean, null, 2) }] };
         }
         catch (err) {
             return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
@@ -45,7 +88,34 @@ export function registerDomainTools(server, getClient) {
     }, async ({ domainName }) => {
         try {
             const result = await requireClient(getClient).execute('namecheap.domains.getInfo', { DomainName: domainName });
-            return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+            const r = result?.['DomainGetInfoResult'];
+            if (!r)
+                return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+            const wg = r['Whoisguard'];
+            const dns = r['DnsDetails'];
+            const nameservers = dns?.['Nameserver'];
+            const nsList = Array.isArray(nameservers) ? nameservers : nameservers ? [nameservers] : [];
+            const clean = {
+                domain: r['@_DomainName'],
+                status: r['@_Status'],
+                id: r['@_ID'],
+                owner: r['@_OwnerName'],
+                created: r['DomainDetails']?.['CreatedDate'],
+                expires: r['DomainDetails']?.['ExpiredDate'],
+                expired: r['@_IsExpired'] === 'true',
+                locked: r['@_IsLocked'] === 'true',
+                autoRenew: r['@_AutoRenew'] === 'true',
+                whoisGuard: wg ? {
+                    enabled: wg['@_Enabled'] === 'true',
+                    id: wg['@_ID'],
+                    expires: wg['@_ExpiredDate'],
+                } : null,
+                dns: {
+                    type: dns?.['@_ProviderType'],
+                    nameservers: nsList,
+                },
+            };
+            return { content: [{ type: 'text', text: JSON.stringify(clean, null, 2) }] };
         }
         catch (err) {
             return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
@@ -99,6 +169,68 @@ export function registerDomainTools(server, getClient) {
                 transferable: t['@_IsApiTransferable'],
             }));
             return { content: [{ type: 'text', text: JSON.stringify(slim, null, 2) }] };
+        }
+        catch (err) {
+            return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+        }
+    });
+    server.registerTool('set_domain_autorenew', {
+        description: 'Enable or disable auto-renewal for a domain.',
+        inputSchema: {
+            domainName: z.string().describe('The domain name, e.g. "example.com"'),
+            autoRenew: z.boolean().describe('true to enable auto-renewal, false to disable'),
+        },
+    }, async ({ domainName, autoRenew }) => {
+        try {
+            await requireClient(getClient).execute('namecheap.domains.autoRenew', {
+                DomainName: domainName,
+                flag: autoRenew ? 'true' : 'false',
+            });
+            return { content: [{ type: 'text', text: JSON.stringify({ domain: domainName, autoRenew }, null, 2) }] };
+        }
+        catch (err) {
+            return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+        }
+    });
+    server.registerTool('set_whoisguard', {
+        description: 'Enable or disable WHOIS guard (privacy protection) for a domain. WHOIS guard must already be purchased/allocated to the domain.',
+        inputSchema: {
+            domainName: z.string().describe('The domain name, e.g. "example.com"'),
+            enable: z.boolean().describe('true to enable WHOIS guard, false to disable'),
+        },
+    }, async ({ domainName, enable }) => {
+        try {
+            const client = requireClient(getClient);
+            const info = await client.execute('namecheap.domains.getInfo', { DomainName: domainName });
+            const wg = info?.['DomainGetInfoResult']?.['Whoisguard'];
+            if (!wg || wg['@_Enabled'] === 'NOTPRESENT') {
+                return {
+                    content: [{ type: 'text', text: `No WHOIS guard subscription found for ${domainName}. Purchase WHOIS guard first.` }],
+                    isError: true,
+                };
+            }
+            const whoisguardId = wg['@_ID'];
+            const command = enable ? 'namecheap.whoisguard.enable' : 'namecheap.whoisguard.disable';
+            await client.execute(command, { WhoisguardId: whoisguardId });
+            return { content: [{ type: 'text', text: JSON.stringify({ domain: domainName, whoisGuard: enable ? 'ENABLED' : 'DISABLED' }, null, 2) }] };
+        }
+        catch (err) {
+            return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+        }
+    });
+    server.registerTool('set_registrar_lock', {
+        description: 'Lock or unlock the registrar lock (transfer lock) for a domain. A locked domain cannot be transferred to another registrar.',
+        inputSchema: {
+            domainName: z.string().describe('The domain name, e.g. "example.com"'),
+            locked: z.boolean().describe('true to lock the domain, false to unlock'),
+        },
+    }, async ({ domainName, locked }) => {
+        try {
+            await requireClient(getClient).execute('namecheap.domains.setRegistrarLock', {
+                DomainName: domainName,
+                LockAction: locked ? 'LOCK' : 'UNLOCK',
+            });
+            return { content: [{ type: 'text', text: JSON.stringify({ domain: domainName, locked }, null, 2) }] };
         }
         catch (err) {
             return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };

--- a/dist/tools/setup.js
+++ b/dist/tools/setup.js
@@ -118,9 +118,9 @@ export function registerSetupTool(server, getClient, setClient) {
         process.env['NAMECHEAP_USERNAME'] = userName;
         process.env['NAMECHEAP_SANDBOX'] = sandbox ? 'true' : 'false';
         // Validate credentials before activating the client
+        const newClient = new NamecheapClient({ apiUser, apiKey, userName, clientIp, sandbox });
         try {
-            await new NamecheapClient({ apiUser, apiKey, userName, clientIp, sandbox })
-                .execute('namecheap.users.getBalances', {});
+            await newClient.execute('namecheap.users.getBalances', {});
         }
         catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
@@ -134,7 +134,7 @@ export function registerSetupTool(server, getClient, setClient) {
             };
         }
         // Activate the new client immediately — no server restart needed
-        setClient(new NamecheapClient({ apiUser, apiKey, userName, clientIp, sandbox }));
+        setClient(newClient);
         return {
             content: [{
                     type: 'text',

--- a/dist/tools/setup.js
+++ b/dist/tools/setup.js
@@ -117,6 +117,22 @@ export function registerSetupTool(server, getClient, setClient) {
         process.env['NAMECHEAP_CLIENT_IP'] = clientIp;
         process.env['NAMECHEAP_USERNAME'] = userName;
         process.env['NAMECHEAP_SANDBOX'] = sandbox ? 'true' : 'false';
+        // Validate credentials before activating the client
+        try {
+            await new NamecheapClient({ apiUser, apiKey, userName, clientIp, sandbox })
+                .execute('namecheap.users.getBalances', {});
+        }
+        catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return {
+                content: [{
+                        type: 'text',
+                        text: `Credentials saved to ${USER_CONFIG_PATH}, but validation failed: ${msg}\n\n` +
+                            `Fix the issue and call \`setup\` again, or verify your API key and whitelisted IP at ap.www.namecheap.com/settings/tools/apiaccess/`,
+                    }],
+                isError: true,
+            };
+        }
         // Activate the new client immediately — no server restart needed
         setClient(new NamecheapClient({ apiUser, apiKey, userName, clientIp, sandbox }));
         return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "namecheap-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "MCP server for the Namecheap API — domains, DNS, SSL, and account management",
   "type": "module",
   "main": "dist/index.js",

--- a/src/client.ts
+++ b/src/client.ts
@@ -108,9 +108,16 @@ export class NamecheapClient {
       const first = errorList[0];
       const code = String(first?.['@_Number'] ?? 'UNKNOWN');
       let message = String(first?.['#text'] ?? 'Unknown error');
-      if (code === '1011102' || code === '1011150') {
-        message += ' — ensure NAMECHEAP_CLIENT_IP is set to your whitelisted public IP address';
-      }
+      const ERROR_HINTS: Record<string, string> = {
+        '1011102': ' — ensure NAMECHEAP_CLIENT_IP is whitelisted at ap.www.namecheap.com/settings/tools/apiaccess/',
+        '1011150': ' — ensure NAMECHEAP_CLIENT_IP is whitelisted at ap.www.namecheap.com/settings/tools/apiaccess/',
+        '2016166': ' — domain not found in your account',
+        '2019166': ' — domain is locked; use set_registrar_lock to unlock before this operation',
+        '3031510': ' — insufficient account balance',
+        '2030280': ' — invalid nameserver format',
+      };
+      const hint = ERROR_HINTS[code];
+      if (hint) message += hint;
       throw new NamecheapApiError(message, code, command);
     }
 

--- a/src/tools/account.ts
+++ b/src/tools/account.ts
@@ -14,7 +14,16 @@ export function registerAccountTools(server: McpServer, getClient: () => Nameche
     async () => {
       try {
         const result = await requireClient(getClient).execute('namecheap.users.getBalances', {});
-        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+        const r = (result as Record<string, Record<string, string>>)?.['UserGetBalancesResult'] ?? {};
+        const clean = {
+          currency: r['@_Currency'] ?? '',
+          availableBalance: parseFloat(r['@_AvailableBalance'] ?? '0'),
+          accountBalance: parseFloat(r['@_AccountBalance'] ?? '0'),
+          earnedAmount: parseFloat(r['@_EarnedAmount'] ?? '0'),
+          withdrawableAmount: parseFloat(r['@_WithdrawableAmount'] ?? '0'),
+          fundsRequiredForAutoRenew: parseFloat(r['@_FundsRequiredForAutoRenew'] ?? '0'),
+        };
+        return { content: [{ type: 'text', text: JSON.stringify(clean, null, 2) }] };
       } catch (err) {
         return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
       }

--- a/src/tools/dns.ts
+++ b/src/tools/dns.ts
@@ -4,6 +4,36 @@ import { NamecheapClient } from '../client.js';
 import { HostRecord } from '../types.js';
 import { requireClient } from '../config.js';
 
+const RECORD_TYPES = ['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'URL', 'URL301', 'FRAME'] as const;
+
+type RawHost = Record<string, string>;
+
+function parseHosts(result: unknown): RawHost[] {
+  const r = (result as Record<string, unknown>)?.['DomainDNSGetHostsResult'] as Record<string, unknown> | undefined;
+  const raw = r?.['Host'];
+  return Array.isArray(raw) ? raw as RawHost[] : raw ? [raw as RawHost] : [];
+}
+
+function cleanHosts(result: unknown): { domain: string; usingNamecheapDns: boolean; emailType: string; hosts: unknown[] } {
+  const r = (result as Record<string, unknown>)?.['DomainDNSGetHostsResult'] as Record<string, string & Record<string, unknown>> | undefined;
+  const raw = r?.['Host'];
+  const list: RawHost[] = Array.isArray(raw) ? raw as RawHost[] : raw ? [raw as RawHost] : [];
+  return {
+    domain: r?.['@_Domain'] ?? '',
+    usingNamecheapDns: r?.['@_IsUsingOurDNS'] === 'true',
+    emailType: r?.['@_EmailType'] ?? '',
+    hosts: list.map(h => ({
+      id: h['@_HostId'],
+      name: h['@_Name'],
+      type: h['@_Type'],
+      address: h['@_Address'],
+      ttl: parseInt(h['@_TTL'] ?? '1800', 10),
+      mxPref: parseInt(h['@_MXPref'] ?? '0', 10),
+      active: h['@_IsActive'] === 'true',
+    })),
+  };
+}
+
 export function registerDnsTools(server: McpServer, getClient: () => NamecheapClient | null): void {
 
   server.registerTool(
@@ -17,7 +47,7 @@ export function registerDnsTools(server: McpServer, getClient: () => NamecheapCl
         const client = requireClient(getClient);
         const { sld, tld } = client.splitDomain(domainName);
         const result = await client.execute('namecheap.domains.dns.getHosts', { SLD: sld, TLD: tld });
-        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+        return { content: [{ type: 'text', text: JSON.stringify(cleanHosts(result), null, 2) }] };
       } catch (err) {
         return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
       }
@@ -32,8 +62,7 @@ export function registerDnsTools(server: McpServer, getClient: () => NamecheapCl
         domainName: z.string().describe('The domain name, e.g. "example.com"'),
         hosts: z.array(z.object({
           hostName: z.string().describe('Host/subdomain name. Use "@" for root, "*" for wildcard.'),
-          recordType: z.enum(['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'URL', 'URL301', 'FRAME'])
-            .describe('DNS record type'),
+          recordType: z.enum(RECORD_TYPES).describe('DNS record type'),
           address: z.string().describe('Record value (IP address, hostname, or URL)'),
           mxPref: z.number().int().min(0).max(65535).optional().describe('MX priority (required for MX records, 0–65535)'),
           ttl: z.number().int().optional().describe('TTL in seconds (default: 1800)'),
@@ -54,6 +83,97 @@ export function registerDnsTools(server: McpServer, getClient: () => NamecheapCl
           'POST'
         );
         return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+      }
+    }
+  );
+
+  server.registerTool(
+    'update_dns_record',
+    {
+      description:
+        'Safely adds, updates, or removes a single DNS record without affecting other records. ' +
+        'Performs an internal read-modify-write — no need to call get_dns_hosts first. ' +
+        'For upsert: finds a matching record by hostName + recordType (MX records also match on address) and replaces it, or appends if not found. ' +
+        'For delete: removes the matching record.',
+      inputSchema: {
+        domainName: z.string().describe('The domain name, e.g. "example.com"'),
+        operation: z.enum(['upsert', 'delete']).describe('"upsert" to add or update a record, "delete" to remove it'),
+        record: z.object({
+          hostName: z.string().describe('Host/subdomain name. Use "@" for root, "*" for wildcard.'),
+          recordType: z.enum(RECORD_TYPES).describe('DNS record type'),
+          address: z.string().optional().describe('Record value (required for upsert)'),
+          mxPref: z.number().int().min(0).max(65535).optional().describe('MX priority (required for MX upsert)'),
+          ttl: z.number().int().optional().describe('TTL in seconds (default: 1800)'),
+        }).describe('The record to add, update, or delete'),
+      },
+    },
+    async ({ domainName, operation, record }) => {
+      try {
+        const client = requireClient(getClient);
+        const { sld, tld } = client.splitDomain(domainName);
+
+        if (operation === 'upsert' && !record.address) {
+          return { content: [{ type: 'text', text: 'Error: address is required for upsert' }], isError: true };
+        }
+        if (operation === 'upsert' && record.recordType === 'MX' && record.mxPref === undefined) {
+          return { content: [{ type: 'text', text: 'Error: mxPref is required for MX upsert' }], isError: true };
+        }
+
+        // Read current records
+        const existing = await client.execute('namecheap.domains.dns.getHosts', { SLD: sld, TLD: tld });
+        const rawHosts = parseHosts(existing);
+
+        // Convert raw hosts to HostRecord format
+        const currentRecords: HostRecord[] = rawHosts.map(h => ({
+          hostName: h['@_Name'] ?? '',
+          recordType: h['@_Type'] as HostRecord['recordType'],
+          address: h['@_Address'] ?? '',
+          mxPref: h['@_MXPref'] ? parseInt(h['@_MXPref'], 10) : undefined,
+          ttl: h['@_TTL'] ? parseInt(h['@_TTL'], 10) : 1800,
+        }));
+
+        const isMx = record.recordType === 'MX';
+        const matches = (h: HostRecord) =>
+          h.hostName === record.hostName &&
+          h.recordType === record.recordType &&
+          (!isMx || h.address === record.address);
+
+        let updatedRecords: HostRecord[];
+        if (operation === 'delete') {
+          updatedRecords = currentRecords.filter(h => !matches(h));
+        } else {
+          const newRecord: HostRecord = {
+            hostName: record.hostName,
+            recordType: record.recordType as HostRecord['recordType'],
+            address: record.address!,
+            mxPref: record.mxPref,
+            ttl: record.ttl ?? 1800,
+          };
+          const idx = currentRecords.findIndex(h => matches(h));
+          if (idx >= 0) {
+            updatedRecords = [...currentRecords];
+            updatedRecords[idx] = newRecord;
+          } else {
+            updatedRecords = [...currentRecords, newRecord];
+          }
+        }
+
+        const hostParams = client.flattenHostRecords(updatedRecords);
+        await client.execute('namecheap.domains.dns.setHosts', { SLD: sld, TLD: tld, ...hostParams }, 'POST');
+
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              operation,
+              domain: domainName,
+              record: { hostName: record.hostName, type: record.recordType },
+              totalRecords: updatedRecords.length,
+            }, null, 2),
+          }],
+        };
       } catch (err) {
         return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
       }

--- a/src/tools/dns.ts
+++ b/src/tools/dns.ts
@@ -134,11 +134,13 @@ export function registerDnsTools(server: McpServer, getClient: () => NamecheapCl
           ttl: h['@_TTL'] ? parseInt(h['@_TTL'], 10) : 1800,
         }));
 
-        const isMx = record.recordType === 'MX';
+        // For MX records, also match on address when provided (multiple MX records
+        // with different addresses can share the same hostName + recordType).
+        // When address is omitted on a delete, match all MX records at that hostName.
         const matches = (h: HostRecord) =>
           h.hostName === record.hostName &&
           h.recordType === record.recordType &&
-          (!isMx || h.address === record.address);
+          (record.recordType !== 'MX' || !record.address || h.address === record.address);
 
         let updatedRecords: HostRecord[];
         if (operation === 'delete') {

--- a/src/tools/domains.ts
+++ b/src/tools/domains.ts
@@ -123,7 +123,7 @@ export function registerDomainTools(server: McpServer, getClient: () => Namechea
           locked: r['@_IsLocked'] === 'true',
           autoRenew: r['@_AutoRenew'] === 'true',
           whoisGuard: wg ? {
-            enabled: wg['@_Enabled'] === 'true',
+            enabled: wg['@_Enabled'] === 'ENABLED',
             id: wg['@_ID'],
             expires: wg['@_ExpiredDate'],
           } : null,
@@ -221,7 +221,7 @@ export function registerDomainTools(server: McpServer, getClient: () => Namechea
       try {
         await requireClient(getClient).execute('namecheap.domains.autoRenew', {
           DomainName: domainName,
-          flag: autoRenew ? 'true' : 'false',
+          Flag: autoRenew ? 'true' : 'false',
         });
         return { content: [{ type: 'text', text: JSON.stringify({ domain: domainName, autoRenew }, null, 2) }] };
       } catch (err) {
@@ -253,6 +253,12 @@ export function registerDomainTools(server: McpServer, getClient: () => Namechea
         }
 
         const whoisguardId = wg['@_ID'];
+        if (!whoisguardId) {
+          return {
+            content: [{ type: 'text', text: `WHOIS guard ID missing for ${domainName} — cannot enable/disable.` }],
+            isError: true,
+          };
+        }
         const command = enable ? 'namecheap.whoisguard.enable' : 'namecheap.whoisguard.disable';
         await client.execute(command, { WhoisguardId: whoisguardId });
         return { content: [{ type: 'text', text: JSON.stringify({ domain: domainName, whoisGuard: enable ? 'ENABLED' : 'DISABLED' }, null, 2) }] };

--- a/src/tools/domains.ts
+++ b/src/tools/domains.ts
@@ -14,7 +14,20 @@ export function registerDomainTools(server: McpServer, getClient: () => Namechea
     async ({ domains }) => {
       try {
         const result = await requireClient(getClient).execute('namecheap.domains.check', { DomainList: domains });
-        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+        const raw = (result as Record<string, unknown>)?.['DomainCheckResult'];
+        const list = Array.isArray(raw) ? raw : raw ? [raw] : [];
+        type RawCheck = Record<string, string>;
+        const clean = (list as RawCheck[]).map(d => {
+          const isPremium = d['@_IsPremiumName'] === 'true';
+          const entry: Record<string, unknown> = {
+            domain: d['@_Domain'],
+            available: d['@_Available'] === 'true',
+            isPremium,
+          };
+          if (isPremium) entry['premiumPrice'] = parseFloat(d['@_PremiumRegistrationPrice'] ?? '0');
+          return entry;
+        });
+        return { content: [{ type: 'text', text: JSON.stringify(clean, null, 2) }] };
       } catch (err) {
         return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
       }
@@ -24,7 +37,7 @@ export function registerDomainTools(server: McpServer, getClient: () => Namechea
   server.registerTool(
     'list_domains',
     {
-      description: 'List all domains in your Namecheap account. Supports pagination and search filtering.',
+      description: 'List all domains in your Namecheap account. Supports pagination and search filtering. Call with increasing page values until hasNextPage is false to retrieve all domains.',
       inputSchema: {
         page: z.number().int().min(1).optional().describe('Page number (default: 1)'),
         pageSize: z.number().int().min(1).max(100).optional().describe('Results per page, max 100 (default: 20)'),
@@ -35,14 +48,47 @@ export function registerDomainTools(server: McpServer, getClient: () => Namechea
     async ({ page, pageSize, searchTerm, listType }) => {
       try {
         const client = requireClient(getClient);
+        const currentPage = page ?? 1;
+        const currentPageSize = pageSize ?? 20;
         const params: Record<string, string | number> = {
-          Page: page ?? 1,
-          PageSize: pageSize ?? 20,
+          Page: currentPage,
+          PageSize: currentPageSize,
         };
         if (searchTerm) params['SearchTerm'] = searchTerm;
         if (listType) params['ListType'] = listType;
         const result = await client.execute('namecheap.domains.getList', params);
-        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+        const r = result as Record<string, unknown>;
+        const raw = r?.['DomainGetListResult'] as Record<string, unknown> | undefined;
+        const paging = r?.['Paging'] as Record<string, string> | undefined;
+
+        const domainList = raw?.['Domain'];
+        const list = Array.isArray(domainList) ? domainList : domainList ? [domainList] : [];
+        type RawDomain = Record<string, string>;
+        const domainsMapped = (list as RawDomain[]).map(d => ({
+          id: d['@_ID'],
+          name: d['@_Name'],
+          created: d['@_Created'],
+          expires: d['@_Expires'],
+          expired: d['@_IsExpired'] === 'true',
+          locked: d['@_IsLocked'] === 'true',
+          autoRenew: d['@_AutoRenew'] === 'true',
+          whoisGuard: d['@_WhoisGuard'],
+          usingNamecheapDns: d['@_IsOurDNS'] === 'true',
+        }));
+
+        const totalItems = parseInt(paging?.['TotalItems'] ?? '0', 10);
+        const totalPages = Math.ceil(totalItems / currentPageSize);
+        const clean = {
+          domains: domainsMapped,
+          pagination: {
+            page: currentPage,
+            pageSize: currentPageSize,
+            totalItems,
+            totalPages,
+            hasNextPage: currentPage < totalPages,
+          },
+        };
+        return { content: [{ type: 'text', text: JSON.stringify(clean, null, 2) }] };
       } catch (err) {
         return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
       }
@@ -58,7 +104,35 @@ export function registerDomainTools(server: McpServer, getClient: () => Namechea
     async ({ domainName }) => {
       try {
         const result = await requireClient(getClient).execute('namecheap.domains.getInfo', { DomainName: domainName });
-        return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+        const r = (result as Record<string, unknown>)?.['DomainGetInfoResult'] as Record<string, unknown> | undefined;
+        if (!r) return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+
+        const wg = r['Whoisguard'] as Record<string, string> | undefined;
+        const dns = r['DnsDetails'] as Record<string, unknown> | undefined;
+        const nameservers = dns?.['Nameserver'];
+        const nsList = Array.isArray(nameservers) ? nameservers : nameservers ? [nameservers] : [];
+
+        const clean: Record<string, unknown> = {
+          domain: r['@_DomainName'],
+          status: r['@_Status'],
+          id: r['@_ID'],
+          owner: r['@_OwnerName'],
+          created: (r['DomainDetails'] as Record<string, string> | undefined)?.['CreatedDate'],
+          expires: (r['DomainDetails'] as Record<string, string> | undefined)?.['ExpiredDate'],
+          expired: r['@_IsExpired'] === 'true',
+          locked: r['@_IsLocked'] === 'true',
+          autoRenew: r['@_AutoRenew'] === 'true',
+          whoisGuard: wg ? {
+            enabled: wg['@_Enabled'] === 'true',
+            id: wg['@_ID'],
+            expires: wg['@_ExpiredDate'],
+          } : null,
+          dns: {
+            type: dns?.['@_ProviderType'],
+            nameservers: nsList,
+          },
+        };
+        return { content: [{ type: 'text', text: JSON.stringify(clean, null, 2) }] };
       } catch (err) {
         return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
       }
@@ -128,6 +202,82 @@ export function registerDomainTools(server: McpServer, getClient: () => Namechea
         }));
 
         return { content: [{ type: 'text', text: JSON.stringify(slim, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+      }
+    }
+  );
+
+  server.registerTool(
+    'set_domain_autorenew',
+    {
+      description: 'Enable or disable auto-renewal for a domain.',
+      inputSchema: {
+        domainName: z.string().describe('The domain name, e.g. "example.com"'),
+        autoRenew: z.boolean().describe('true to enable auto-renewal, false to disable'),
+      },
+    },
+    async ({ domainName, autoRenew }) => {
+      try {
+        await requireClient(getClient).execute('namecheap.domains.autoRenew', {
+          DomainName: domainName,
+          flag: autoRenew ? 'true' : 'false',
+        });
+        return { content: [{ type: 'text', text: JSON.stringify({ domain: domainName, autoRenew }, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+      }
+    }
+  );
+
+  server.registerTool(
+    'set_whoisguard',
+    {
+      description: 'Enable or disable WHOIS guard (privacy protection) for a domain. WHOIS guard must already be purchased/allocated to the domain.',
+      inputSchema: {
+        domainName: z.string().describe('The domain name, e.g. "example.com"'),
+        enable: z.boolean().describe('true to enable WHOIS guard, false to disable'),
+      },
+    },
+    async ({ domainName, enable }) => {
+      try {
+        const client = requireClient(getClient);
+        const info = await client.execute('namecheap.domains.getInfo', { DomainName: domainName });
+        const wg = ((info as Record<string, unknown>)?.['DomainGetInfoResult'] as Record<string, unknown> | undefined)?.['Whoisguard'] as Record<string, string> | undefined;
+
+        if (!wg || wg['@_Enabled'] === 'NOTPRESENT') {
+          return {
+            content: [{ type: 'text', text: `No WHOIS guard subscription found for ${domainName}. Purchase WHOIS guard first.` }],
+            isError: true,
+          };
+        }
+
+        const whoisguardId = wg['@_ID'];
+        const command = enable ? 'namecheap.whoisguard.enable' : 'namecheap.whoisguard.disable';
+        await client.execute(command, { WhoisguardId: whoisguardId });
+        return { content: [{ type: 'text', text: JSON.stringify({ domain: domainName, whoisGuard: enable ? 'ENABLED' : 'DISABLED' }, null, 2) }] };
+      } catch (err) {
+        return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
+      }
+    }
+  );
+
+  server.registerTool(
+    'set_registrar_lock',
+    {
+      description: 'Lock or unlock the registrar lock (transfer lock) for a domain. A locked domain cannot be transferred to another registrar.',
+      inputSchema: {
+        domainName: z.string().describe('The domain name, e.g. "example.com"'),
+        locked: z.boolean().describe('true to lock the domain, false to unlock'),
+      },
+    },
+    async ({ domainName, locked }) => {
+      try {
+        await requireClient(getClient).execute('namecheap.domains.setRegistrarLock', {
+          DomainName: domainName,
+          LockAction: locked ? 'LOCK' : 'UNLOCK',
+        });
+        return { content: [{ type: 'text', text: JSON.stringify({ domain: domainName, locked }, null, 2) }] };
       } catch (err) {
         return { content: [{ type: 'text', text: `Error: ${err instanceof Error ? err.message : String(err)}` }], isError: true };
       }

--- a/src/tools/setup.ts
+++ b/src/tools/setup.ts
@@ -137,9 +137,9 @@ export function registerSetupTool(
       process.env['NAMECHEAP_SANDBOX'] = sandbox ? 'true' : 'false';
 
       // Validate credentials before activating the client
+      const newClient = new NamecheapClient({ apiUser, apiKey, userName, clientIp, sandbox });
       try {
-        await new NamecheapClient({ apiUser, apiKey, userName, clientIp, sandbox })
-          .execute('namecheap.users.getBalances', {});
+        await newClient.execute('namecheap.users.getBalances', {});
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         return {
@@ -154,7 +154,7 @@ export function registerSetupTool(
       }
 
       // Activate the new client immediately — no server restart needed
-      setClient(new NamecheapClient({ apiUser, apiKey, userName, clientIp, sandbox }));
+      setClient(newClient);
 
       return {
         content: [{

--- a/src/tools/setup.ts
+++ b/src/tools/setup.ts
@@ -136,6 +136,23 @@ export function registerSetupTool(
       process.env['NAMECHEAP_USERNAME'] = userName;
       process.env['NAMECHEAP_SANDBOX'] = sandbox ? 'true' : 'false';
 
+      // Validate credentials before activating the client
+      try {
+        await new NamecheapClient({ apiUser, apiKey, userName, clientIp, sandbox })
+          .execute('namecheap.users.getBalances', {});
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{
+            type: 'text' as const,
+            text:
+              `Credentials saved to ${USER_CONFIG_PATH}, but validation failed: ${msg}\n\n` +
+              `Fix the issue and call \`setup\` again, or verify your API key and whitelisted IP at ap.www.namecheap.com/settings/tools/apiaccess/`,
+          }],
+          isError: true,
+        };
+      }
+
       // Activate the new client immediately — no server restart needed
       setClient(new NamecheapClient({ apiUser, apiKey, userName, clientIp, sandbox }));
 


### PR DESCRIPTION
## Summary

- **Output transforms**: 5 tools now return clean, flat JSON instead of raw XML-parsed responses with `@_`-prefixed attribute names — `get_balances`, `list_domains`, `get_domain_info`, `check_domains`, `get_dns_hosts`
- **New tools**: `update_dns_record` (safe read-modify-write), `set_domain_autorenew`, `set_whoisguard`, `set_registrar_lock`
- **Setup validation**: credentials are now tested against the API before activating the client
- **Error hints**: common API error codes now include actionable messages

## New tool details

| Tool | Description |
|---|---|
| `update_dns_record` | Add, update, or delete a single DNS record without affecting others. Internal read-modify-write — no need to fetch records first. |
| `set_domain_autorenew` | Toggle auto-renewal on/off |
| `set_whoisguard` | Enable/disable WHOIS privacy (handles two-step API lookup internally) |
| `set_registrar_lock` | Lock or unlock domain transfer |

## Breaking changes

Output shapes for `get_balances`, `list_domains`, `get_domain_info`, `check_domains`, and `get_dns_hosts` have changed from raw XML-parsed JSON to clean flat objects. Any consumer relying on `@_`-prefixed keys will need to update.

## Test plan

- [ ] `get_balances` returns `{ currency, availableBalance, ... }` with numeric values
- [ ] `list_domains` returns `{ domains, pagination: { hasNextPage, totalPages, ... } }`
- [ ] `get_domain_info` returns flat object with nested `dns` and `whoisGuard`
- [ ] `check_domains` returns `[{ domain, available, isPremium }]`
- [ ] `get_dns_hosts` returns `{ domain, hosts: [{ name, type, address, ttl, ... }] }`
- [ ] `update_dns_record` upsert adds a new record without removing existing ones
- [ ] `update_dns_record` delete removes only the targeted record
- [ ] `set_domain_autorenew` toggles the flag successfully
- [ ] `setup` with bad credentials shows validation error but saves config file
- [ ] `setup` with good credentials activates client immediately